### PR TITLE
Creation of Additional Effect: Dispel (dispelled effects always show …

### DIFF
--- a/scripts/globals/items/claustrum.lua
+++ b/scripts/globals/items/claustrum.lua
@@ -10,15 +10,12 @@ require("scripts/globals/status");
 -----------------------------------
 
 function onAdditionalEffect(player,target,damage)
-    chance = 15;
-    if (chance > math.random(0,99)) then
-        local dispel = target:dispelStatusEffect();
-        if (dispel == EFFECT_NONE) then
+    local chance = 20; 
+	
+    if (math.random(0,99) >= chance) then
             return 0,0,0;
-        else
-            return SUBEFFECT_DISPEL, MSGBASIC_ADD_EFFECT_DISPEL, dispel;
-        end
-    else
-        return 0,0,0;
-    end
+		else
+			target:dispelStatusEffect();
+			return SUBEFFECT_DISPEL, MSGBASIC_ADD_EFFECT_DISPEL, MSG_DISPEL;
+	end
 end;


### PR DESCRIPTION
…up as KO is Core issue

With Creation of code for additional effect Dispel: Luas created for all (Non-Enchanted, no Dispel Couse) Weapons: Balmung.lua, Mythril_Heart.lua, Mythril_Heart_+1.lua
claustrum.lua code altered to have an actual effect rather than slinging errors everywhere

Signed-off-by: aarondemoncia <dragonwizard@kc.rr.com>